### PR TITLE
Allow a `prompt` key in config files

### DIFF
--- a/itomate/itomate.py
+++ b/itomate/itomate.py
@@ -185,8 +185,9 @@ async def activate(connection):
             commands = pane.get('commands') or []
             if root_path:
                 commands.insert(0, f"cd {root_path}")
-                for command in commands:
-                    command += "\n"
+
+            for command in commands:
+                command += "\n"
 
             prompt = pane.get('prompt') or ''
             if prompt:

--- a/itomate/itomate.py
+++ b/itomate/itomate.py
@@ -9,7 +9,7 @@ import iterm2
 import yaml
 
 default_config = 'itomate.yml'
-version = '0.3.6'
+version = '0.3.7'
 
 class ItomateException(Exception):
     """Raise for our custom exceptions"""

--- a/itomate/itomate.py
+++ b/itomate/itomate.py
@@ -87,10 +87,6 @@ async def render_tab_panes(tab, panes, pofile_name):
         for command in pane_commands:
             await current_session.async_send_text(f"{command}\n")
 
-        # Leave a command in the prompt, awaiting execution
-        pane_prompt = current_session.get("prompt") or ""
-        current_session.async_send_text(f"{pane_prompt}")
-
     # For each of the vertical panes rendered above, render the sub panes now
     # e.g. 1/2, 1/3, 1/4, 1/5 ... 2/2, 2/3, 2/4, ... and so on
     for vertical_pane_counter in list(range(1, 10)):
@@ -125,10 +121,6 @@ async def render_tab_panes(tab, panes, pofile_name):
             pane_commands = horizontal_pane.get('commands') or []
             for command in pane_commands:
                 await current_session.async_send_text(f"{command}\n")
-
-            # Leave a command in the prompt, awaiting execution
-            pane_prompt = horizontal_pane.get("prompt") or ""
-            current_session.async_send_text(f"{pane_prompt}")
 
         await focus_session.async_activate()
 
@@ -192,7 +184,12 @@ async def activate(connection):
         if root_path:
             for pane in tab_panes:
                 commands = pane.get('commands') or []
+                prompt = pane.get('prompt') or ''
+
                 commands.insert(0, f"cd {root_path}")
+                if prompt:
+                    commands.append(prompt)
+
                 pane['commands'] = commands
 
         await curr_tab.async_set_title(tab_title)

--- a/itomate/itomate.py
+++ b/itomate/itomate.py
@@ -87,6 +87,10 @@ async def render_tab_panes(tab, panes, pofile_name):
         for command in pane_commands:
             await current_session.async_send_text(f"{command}\n")
 
+        # Leave a command in the prompt, awaiting execution
+        pane_prompt = current_session.get("prompt") or ""
+        current_session.async_send_text(f"{pane_prompt}")
+
     # For each of the vertical panes rendered above, render the sub panes now
     # e.g. 1/2, 1/3, 1/4, 1/5 ... 2/2, 2/3, 2/4, ... and so on
     for vertical_pane_counter in list(range(1, 10)):
@@ -121,6 +125,10 @@ async def render_tab_panes(tab, panes, pofile_name):
             pane_commands = horizontal_pane.get('commands') or []
             for command in pane_commands:
                 await current_session.async_send_text(f"{command}\n")
+
+            # Leave a command in the prompt, awaiting execution
+            pane_prompt = horizontal_pane.get("prompt") or ""
+            current_session.async_send_text(f"{pane_prompt}")
 
         await focus_session.async_activate()
 

--- a/itomate/itomate.py
+++ b/itomate/itomate.py
@@ -182,17 +182,17 @@ async def activate(connection):
 
         # Set root path if it exists
         for pane in tab_panes:
+            commands = pane.get('commands') or []
             if root_path:
-                commands = pane.get('commands') or []
                 commands.insert(0, f"cd {root_path}")
                 for command in commands:
                     command += "\n"
 
-                prompt = pane.get('prompt') or ''
-                if prompt:
-                    commands.append(prompt)
+            prompt = pane.get('prompt') or ''
+            if prompt:
+                commands.append(prompt)
 
-                pane['commands'] = commands
+            pane['commands'] = commands
 
         await curr_tab.async_set_title(tab_title)
         await render_tab_panes(curr_tab, tab_panes, profile_name)

--- a/itomate/itomate.py
+++ b/itomate/itomate.py
@@ -85,7 +85,7 @@ async def render_tab_panes(tab, panes, pofile_name):
         # Execute the commands for this pane
         pane_commands = pane.get('commands') or []
         for command in pane_commands:
-            await current_session.async_send_text(f"{command}\n")
+            await current_session.async_send_text(f"{command}")
 
     # For each of the vertical panes rendered above, render the sub panes now
     # e.g. 1/2, 1/3, 1/4, 1/5 ... 2/2, 2/3, 2/4, ... and so on
@@ -120,7 +120,7 @@ async def render_tab_panes(tab, panes, pofile_name):
             # Execute the commands for this pane
             pane_commands = horizontal_pane.get('commands') or []
             for command in pane_commands:
-                await current_session.async_send_text(f"{command}\n")
+                await current_session.async_send_text(f"{command}")
 
         await focus_session.async_activate()
 
@@ -181,12 +181,14 @@ async def activate(connection):
             continue
 
         # Set root path if it exists
-        if root_path:
-            for pane in tab_panes:
+        for pane in tab_panes:
+            if root_path:
                 commands = pane.get('commands') or []
-                prompt = pane.get('prompt') or ''
-
                 commands.insert(0, f"cd {root_path}")
+                for command in commands:
+                    command += "\n"
+
+                prompt = pane.get('prompt') or ''
                 if prompt:
                     commands.append(prompt)
 

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ tabs:
         commands:
          - !ENV "db authenticate ${DB_PASSWORD}"
          - "second command"
+        prompt: "populated command"
       - position: "1/2"
         focus: true
         badge: "Jobs"
@@ -86,10 +87,11 @@ Details for each of the configuration objects above is given below
 | `window-1` | Replace with the unique project id e.g. `web-catalog-pim`                                                                                                                                                                                        |
 | `root`     | Root path for all panes within a tab                                                                                                                                                                                                             |
 | `title`    | Title to be shown in the title bar of the current tab                                                                                                                                                                                            |
-| `badge`    | Set the Badge Text of the pane
+| `badge`    | Set the Badge Text of the pane                                                                                                                                                                                                                   |
 | `position` | Position of the pane in the window. It has the format of `number1/number2` where `number1` refers to the column and `number2` refers to the row in the column. More on this later in the readme. `position` is the only required key in a pane   |
-| `focus`    | Pane to be in focus when itomate is finished. `focus: true`. There should only be one focus flag per Tab. If multiple are found, it will focus on the last pane evaluated.                                                                                                                                   |
+| `focus`    | Pane to be in focus when itomate is finished. `focus: true`. There should only be one focus flag per Tab. If multiple are found, it will focus on the last pane evaluated.                                                                       |
 | `commands` | List of commands to execute in the current pane.                                                                                                                                                                                                 |
+| `prompt`   | A command which will remain populated in the prompt after all `command`s have finished executing. The `prompt` command itself is not executed automatically.                                                                                     |
 
 ## Environment Variables
 Operating System Environment Variables can be used to create templates with secrets and variables. This allows itomate files to be safely committed to version control. Note in the above configuration example the line using the environment variable is prefixed with the  `!ENV` tag and then uses one or more Environment Variables
@@ -282,6 +284,7 @@ Special thanks to the contributors for making iTomate possible
 * [@zakiuu](https://github.com/zakiuu)
 * [@JohnLegrandRichards](https://github.com/JohnLegrandRichards)
 * [@zachvalenta](https://github.com/zachvalenta)
+* [@PSalant726](https://github.com/psalant726)
 * You?
 
 
@@ -292,6 +295,6 @@ There is [itermocil](https://github.com/TomAnthony/itermocil/blob/master/README.
 ## Contributions
 Feel free to submit pull requests, create issues, spread the word.
 
-## License 
+## License
 
 MIT &copy; [Kamran Ahmed](https://twitter.com/kamranahmedse)


### PR DESCRIPTION
The `prompt` key allows the user to specify a command with which to populate the command line in the specified window or pane. The `prompt` command is populated after all commands in the `command` array are executed, and remains in the command line, awaiting manual execution by the user.

This can be useful for automated workflows which populate a user's terminal window with several panes, each ready to display output from a given command that should be run with special care/attention. For example, a user may create a config file to create panes which tail log files for a service, as well as a pane with a long/complex command pre-populated, which would deploy changes to that service when executed.